### PR TITLE
バックテスト時にトレード詳細をログに出力できるようにした

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
     channelBreakOut.fileName = config["fileName"]
     channelBreakOut.showFigure = config["showFigure"]
     channelBreakOut.sendFigure = config["sendFigure"]
+    channelBreakOut.showTradeDetail = config["showTradeDetail"]
 
     #バックテスト
     channelBreakOut.describeResult()

--- a/config_default.json
+++ b/config_default.json
@@ -17,5 +17,6 @@
     "fileName" : "chart.csv",
     "showFigure" : true,
     "sendFigure" : false,
-    "core" : null
+    "core" : null,
+    "showTradeDetail" : true
 }

--- a/src/channel.py
+++ b/src/channel.py
@@ -449,7 +449,10 @@ class ChannelBreakOut:
         #各統計量の計算および表示．
         winTrade = sum([1 for i in plPerTrade if i > 0])
         loseTrade = sum([1 for i in plPerTrade if i < 0])
-        winPer = round(winTrade/(winTrade+loseTrade) * 100,2)
+        try:
+            winPer = round(winTrade/(winTrade+loseTrade) * 100,2)
+        except:
+            winPer = 100
 
         winTotal = sum([i for i in plPerTrade if i > 0])
         loseTotal = sum([i for i in plPerTrade if i < 0])
@@ -458,8 +461,8 @@ class ChannelBreakOut:
         except:
             profitFactor = 10
 
-        maxProfit = max(plPerTrade)
-        maxLoss = min(plPerTrade)
+        maxProfit = max(plPerTrade, default=0)
+        maxLoss = min(plPerTrade, default=0)
 
         logging.info('showFigure :%s, sendFigure :%s',self.showFigure, self.sendFigure)
         logging.info("Total pl: {}JPY".format(int(pl[-1])))

--- a/src/channel.py
+++ b/src/channel.py
@@ -52,6 +52,8 @@ class ChannelBreakOut:
         self.showFigure = False
         # バックテスト結果のグラフをLineで送る
         self.sendFigure = False
+        # バックテストのトレード詳細をログ出力する
+        self.showTradeDetail = False
         # optimization用のOHLCcsvファイル
         self.fileName = None
 
@@ -289,6 +291,8 @@ class ChannelBreakOut:
         originalLot = lot
         #勝ちトレード後，何回のトレードでロットを落とすか．
         waitTerm = 0
+        # 取引履歴 [time, order, price, profit]
+        trade_log = []
         for i in range(len(judgement)):
             if i > 0:
                 lastPL = pl[-1]
@@ -300,11 +304,13 @@ class ChannelBreakOut:
                     pos += 1
                     buy_entry.append(judgement[i][0])
                     buyEntrySignals.append(df_candleStick.index[i])
+                    trade_log.append([df_candleStick.index[i], 'buy  entry', judgement[i][0]])
                 #ショートエントリー
                 elif judgement[i][1] != 0:
                     pos -= 1
                     sell_entry.append(judgement[i][1])
                     sellEntrySignals.append(df_candleStick.index[i])
+                    trade_log.append([df_candleStick.index[i], 'sell entry', judgement[i][1]])
             #ロングクローズロジック
             elif pos == 1:
                 #ロングクローズ
@@ -317,6 +323,7 @@ class ChannelBreakOut:
                     pl[-1] = pl[-2] + (plRange-self.cost) * lot
                     buyCloseSignals.append(df_candleStick.index[i])
                     plPerTrade.append((plRange-self.cost)*lot)
+                    trade_log.append([df_candleStick.index[i], 'buy  close', judgement[i][2], (plRange-self.cost)*lot])
                     #waitTh円以上の値幅を取った場合，次の10トレードはロットを1/10に落とす．
                     if plRange > waitTh:
                         waitTerm = originalWaitTerm
@@ -337,6 +344,7 @@ class ChannelBreakOut:
                     pl[-1] = pl[-2] + (plRange-self.cost) * lot
                     sellCloseSignals.append(df_candleStick.index[i])
                     plPerTrade.append((plRange-self.cost)*lot)
+                    trade_log.append([df_candleStick.index[i], 'sell close', judgement[i][3], (plRange-self.cost)*lot])
                     #waitTh円以上の値幅を取った場合，次の10トレードはロットを1/10に落とす．
                     if plRange > waitTh:
                         waitTerm = originalWaitTerm
@@ -354,11 +362,13 @@ class ChannelBreakOut:
                     pos += 1
                     buy_entry.append(judgement[i][0])
                     buyEntrySignals.append(df_candleStick.index[i])
+                    trade_log.append([df_candleStick.index[i], 'buy  entry', judgement[i][0]])
                 #ショートエントリー
                 elif judgement[i][1] != 0:
                     pos -= 1
                     sell_entry.append(judgement[i][1])
                     sellEntrySignals.append(df_candleStick.index[i])
+                    trade_log.append([df_candleStick.index[i], 'sell entry', judgement[i][1]])
 
         #最後にポジションを持っていたら，期間最後のローソク足の終値で反対売買．
         if pos == 1:
@@ -369,6 +379,7 @@ class ChannelBreakOut:
             buyCloseSignals.append(df_candleStick.index[-1])
             nOfTrade += 1
             plPerTrade.append(plRange*lot)
+            trade_log.append([df_candleStick.index[-1], 'buy  close', df_candleStick["close"][-1], plRange*lot])
         elif pos ==-1:
             sell_close.append(df_candleStick["close"][-1])
             plRange = sell_entry[-1] - sell_close[-1]
@@ -377,7 +388,8 @@ class ChannelBreakOut:
             sellCloseSignals.append(df_candleStick.index[-1])
             nOfTrade += 1
             plPerTrade.append(plRange*lot)
-        return (pl, buyEntrySignals, sellEntrySignals, buyCloseSignals, sellCloseSignals, nOfTrade, plPerTrade)
+            trade_log.append([df_candleStick.index[-1], 'sell close', df_candleStick["close"][-1], plRange*lot])
+        return (pl, buyEntrySignals, sellEntrySignals, buyCloseSignals, sellCloseSignals, nOfTrade, plPerTrade, trade_log)
 
     def describeResult(self):
         """
@@ -399,7 +411,7 @@ class ChannelBreakOut:
         entryLowLine, entryHighLine = self.calculateLines(df_candleStick, self.entryTerm, self.rangePercent, self.rangePercentTerm)
         closeLowLine, closeHighLine = self.calculateLines(df_candleStick, self.closeTerm, self.rangePercent, self.rangePercentTerm)
         judgement = self.judge(df_candleStick, entryHighLine, entryLowLine, closeHighLine, closeLowLine, self.entryTerm)
-        pl, buyEntrySignals, sellEntrySignals, buyCloseSignals, sellCloseSignals, nOfTrade, plPerTrade = self.backtest(judgement, df_candleStick, 1, self.rangeTh, self.rangeTerm, originalWaitTerm=self.waitTerm, waitTh=self.waitTh, cost=self.cost)
+        pl, buyEntrySignals, sellEntrySignals, buyCloseSignals, sellCloseSignals, nOfTrade, plPerTrade, tradeLog = self.backtest(judgement, df_candleStick, 1, self.rangeTh, self.rangeTerm, originalWaitTerm=self.waitTerm, waitTh=self.waitTh, cost=self.cost)
 
         if self.showFigure:
             import matplotlib.pyplot as plt
@@ -470,6 +482,13 @@ class ChannelBreakOut:
         logging.info("The Winning percentage: {}%".format(winPer))
         logging.info("The profitFactor: {}".format(profitFactor))
         logging.info("The maximum Profit and Loss: {}JPY, {}JPY".format(maxProfit, maxLoss))
+        if self.showTradeDetail:
+            logging.info("==Trade detail==")
+            for log in tradeLog:
+                profit = log[3] if len(log) > 3 else ''
+                logging.info("%s %s %s %s", log[0], log[1], log[2], profit)
+            logging.info("============")
+
         if self.showFigure:
             plt.show()
         else:


### PR DESCRIPTION
グラフだけだと「いついくらで買ったのか」がわからないのでログに出力
backtestにのみ適用

example
```
04/11/2018 12:54:37 PM INFO: showFigure :True, sendFigure :False
04/11/2018 12:54:37 PM INFO: Total pl: 4905JPY
04/11/2018 12:54:37 PM INFO: The number of Trades: 1
04/11/2018 12:54:37 PM INFO: The Winning percentage: 100.0%
04/11/2018 12:54:37 PM INFO: The profitFactor: inf
04/11/2018 12:54:37 PM INFO: The maximum Profit and Loss: 4905.0JPY, 4905.0JPY
04/11/2018 12:54:37 PM INFO: ==Trade detail==
04/11/2018 12:54:37 PM INFO: 2018-04-11 01:00:00 buy  entry 738000.0 
04/11/2018 12:54:37 PM INFO: 2018-04-11 11:00:00 buy  close 742905 4905.0
04/11/2018 12:54:37 PM INFO: ============
```