### PR TITLE
backtestした期間をログに追加

### DIFF
--- a/src/channel.py
+++ b/src/channel.py
@@ -477,6 +477,7 @@ class ChannelBreakOut:
         maxLoss = min(plPerTrade, default=0)
 
         logging.info('showFigure :%s, sendFigure :%s',self.showFigure, self.sendFigure)
+        logging.info('Period: %s > %s', df_candleStick.index[0], df_candleStick.index[-1])
         logging.info("Total pl: {}JPY".format(int(pl[-1])))
         logging.info("The number of Trades: {}".format(nOfTrade))
         logging.info("The Winning percentage: {}%".format(winPer))


### PR DESCRIPTION
読み込んだデータの一番最初と最後の日時をログに追加(以下のPeriod)
ex.
```
2018-04-17 17:56:39 INFO: Wait...
2018-04-17 17:56:40 INFO: showFigure :True, sendFigure :False
2018-04-17 17:56:40 INFO: Period: 2018-04-01 02:00:00 > 2018-04-17 18:00:00
2018-04-17 17:56:40 INFO: Total pl: 84740JPY
2018-04-17 17:56:40 INFO: The number of Trades: 27
2018-04-17 17:56:40 INFO: The Winning percentage: 66.67%
2018-04-17 17:56:40 INFO: The profitFactor: 4.974
2018-04-17 17:56:40 INFO: The maximum Profit and Loss: 36230JPY, -14685JPY
```