### PR TITLE
前回のポジションを引き継ぐ機能の追加

### DIFF
--- a/config_default.json
+++ b/config_default.json
@@ -22,5 +22,6 @@
     "core" : null,
     "hyperopt" : 1000,
     "mlMode" : "PL",
-    "useBlackList" : true
+    "useBlackList" : true,
+    "keepPosition" : false
 }

--- a/src/channel.py
+++ b/src/channel.py
@@ -155,10 +155,10 @@ class ChannelBreakOut:
         return round(lot,2)
 
     # 約定履歴ファイル
-    def writeorderhistory(self, price, lot, range, pos):
+    def writeorderhistory(self, priceOrderd, lotOrderd, profitRange, currentPos):
         with open('log/orderhistory.log', 'a') as orderhistoryfile:
             orderhistorycsv = csv.writer(orderhistoryfile, lineterminator='\n')
-            orderhistorycsv.writerow([datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"), price, lot, range, pos])
+            orderhistorycsv.writerow([datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"), priceOrderd, lotOrderd, profitRange, currentPos ])
 
     def calculateLines(self, df_candleStick, term, rangePercent, rangePercentTerm):
         """

--- a/trade.py
+++ b/trade.py
@@ -4,6 +4,7 @@
 import json
 import logging
 from src import channel
+import os
 
 if __name__ == '__main__':
     #logging設定
@@ -39,6 +40,13 @@ if __name__ == '__main__':
     channelBreakOut.waitTh = config["waitTh"]
     channelBreakOut.candleTerm = config["candleTerm"]
     channelBreakOut.fileName = None
+
+    # 約定履歴ファイルを引き継がない場合は削除
+    if config["keepPosition"]==False :
+        try:
+            os.remove( 'log/orderhistory.log' )
+        except:
+            pass
 
     #実働
     channelBreakOut.loop()


### PR DESCRIPTION
前回のポジションを引き継ぐ機能を追加しました。
オーダー時にlog/orderhistory.logに情報を追加し、次回起動時にはそれを読んでpl[]とlastPositionPriceとlotに復元します。
損益グラフも継続できます。
config.jsonで    "keepPosition" : false（デフォルト）にすると上記ファイルを削除しますので引継ぎを行いません。